### PR TITLE
Fixes the keep alive hack to ensure connectivity with Zipato servers

### DIFF
--- a/lib/zipabox.js
+++ b/lib/zipabox.js
@@ -1070,9 +1070,23 @@ function LoginUser_FN(CALLBACK_FN) {
 				writelog("Login error : " + err.red);	
 			}				
 			else{
-				msg = {statusCode: 5, msg:"Login error status code : " + res.statusCode};
-				if (zipabox.events.OnLoginUserProgress) zipabox.events.OnLoginUserProgress(msg);
-				writelog("Login error status code : " + res.statusCode.red);	
+				zipabox.loginUser_Return = JSON.parse(body);
+				
+				//console.log(res.statusCode);
+				if(zipabox.loginUser_Return.error == "Already authenticated") {
+					zipabox.connected = true;
+					msg = {statusCode: 2, msg:"Login [OK]"};
+					if (zipabox.events.OnLoginUserProgress) zipabox.events.OnLoginUserProgress(msg);
+					writelog("Login " + "[OK]".bold);
+
+					if(CALLBACK_FN){
+						CALLBACK_FN(); 
+					} 
+				} else {
+					msg = {statusCode: 5, msg:"Login error status code : " + res.statusCode};
+					if (zipabox.events.OnLoginUserProgress) zipabox.events.OnLoginUserProgress(msg);
+					writelog("Login error status code : " + res.statusCode.red);
+				}
 			}				
 		}
 	);	


### PR DESCRIPTION
Zipato returns a 403 status code and the message "Already authenticated" although the login technically went fine resulting in a failed reconnection.